### PR TITLE
Fix Review Type in firebase.ts 

### DIFF
--- a/api/firebase.ts
+++ b/api/firebase.ts
@@ -15,7 +15,7 @@ import {
   limit,
   startAfter,
 } from 'firebase/firestore/lite';
-import { postingType, usertype, MakeQueryParam, commentType } from './firebase.type';
+import { postingType, usertype, MakeQueryParam, commentType, reviewsType } from './firebase.type';
 import { getStorage, getDownloadURL, ref, uploadString } from 'firebase/storage';
 
 const firebaseConfig = {
@@ -287,7 +287,7 @@ export const addCommunityPosting = async (posting: postingType) => {
   }
 };
 
-export const addReview = async (review: reviewProps) => {
+export const addReview = async (review: reviewsType) => {
   try {
     addDoc(collection(db, 'reviews'), review);
   } catch (e) {

--- a/api/firebase.type.ts
+++ b/api/firebase.type.ts
@@ -36,6 +36,7 @@ interface reviewsType {
   category: string;
   content: string;
   rating: number;
+  creationDate: Date;
   isActivation: boolean;
   trainerId: string;
   userId: string;


### PR DESCRIPTION
addReview에서 인자의 타입체크시 api 폴더 내 타입 파일을 참조하도록 수정하였습니다.